### PR TITLE
 feat/23: 한글로 나오게 하는 메서드 추가

### DIFF
--- a/constants/api-codes.ts
+++ b/constants/api-codes.ts
@@ -71,3 +71,31 @@ export const BARRIER_ICONS = {
 export function getActiveIcons(place: Record<string, string | null>) {
     return Object.entries(BARRIER_ICONS).filter(([key]) => place[key] !== null)
 }
+
+/** 지역 코드를 한글 이름으로 변환하는 객체 */
+export const AreaName: Record<string, string> = {
+    [AreaCode.SEOUL]: '서울',
+    [AreaCode.INCHEON]: '인천',
+    [AreaCode.DAEJEON]: '대전',
+    [AreaCode.DAEGU]: '대구',
+    [AreaCode.GWANGJU]: '광주',
+    [AreaCode.BUSAN]: '부산',
+    [AreaCode.ULSAN]: '울산',
+    [AreaCode.SEJONG]: '세종',
+    [AreaCode.GYEONGGI]: '경기',
+    [AreaCode.GANGWON]: '강원',
+    [AreaCode.CHUNGBUK]: '충북',
+    [AreaCode.CHUNGNAM]: '충남',
+    [AreaCode.GYEONGBUK]: '경북',
+    [AreaCode.GYEONGNAM]: '경남',
+    [AreaCode.JEONBUK]: '전북',
+    [AreaCode.JEONNAM]: '전남',
+    [AreaCode.JEJU]: '제주',
+}
+
+/** 콘텐츠 타입을 한글 이름으로 변환하는 객체 */
+export const ContentTypeName: Record<string, string> = {
+    '12': '관광지',
+    '32': '숙박',
+    '39': '음식점',
+}

--- a/scripts/upload-data.ts
+++ b/scripts/upload-data.ts
@@ -104,7 +104,7 @@ async function processPage(areaCode: string, typeId: string, pageNo: number) {
 
 /** 4. 메인 실행 함수 (Depth가 획기적으로 줄어듬) */
 async function uploadAllData() {
-    const targetAreas = [AreaCode.JEJU] // 이넘 사용
+    const targetAreas = [AreaCode.JEJU]
     const targetTypes = [ContentType.TOURISM, ContentType.LODGING, ContentType.RESTAURANT]
 
     for (const area of targetAreas) {


### PR DESCRIPTION
# 📌 작업 개요
- 공공데이터 지역 코드 및 콘텐츠 타입 코드를 한글로 매핑하는 객체(AreaName, ContentTypeName) 추가

- 무장애 시설 아이콘 렌더링을 위한 유틸리티 함수 및 상수 정의

# 🛠️ 주요 변경 사항
- AreaCode, ContentType, AssistType 상수를 as const 객체로 관리

- 숫자로 된 코드를 한글명으로 변환하는 매핑 객체 추가

# 💻 사용 예시
- 1. 코드 값을 한글명으로 변환할 때
```JavaScript
import { AreaName, ContentTypeName } from '../constants/api-codes.ts';

const receivedAreaCode = '39'; // 문자열로 넣어야함
const receivedTypeCode = '12'; // 상동

console.log(AreaName[receivedAreaCode]);        // "제주"
console.log(ContentTypeName[receivedTypeCode]); // "관광지"
```
- 2. 리액트 컴포넌트에서 렌더링할 때
```TypeScript
{places.map((place) => (
  <div key={place.content_id}>
    <h3>{place.title}</h3>
    {/* 숫자 코드를 한글로 변환하여 출력 */}
    <span>지역: {AreaName[place.area_code] || '미지정'}</span>
    <span>분류: {ContentTypeName[place.content_type]}</span>
  </div>
))}```