### PR TITLE
feat/29: 상세 페이지 내 좋아요 자동 갱신

### DIFF
--- a/src/app/components/post/like-post-button.tsx
+++ b/src/app/components/post/like-post-button.tsx
@@ -13,7 +13,7 @@ export default function LikePostButton({
     isLiked: boolean
 }) {
     const { user } = useAuth()
-    const { mutate: togglePostLike } = useTogglePostLike({
+    const { mutate: togglePostLike } = useTogglePostLike(id, {
         onError: (_error) => {
             toast.error('좋아요 요청에 실패했습니다.', { position: 'top-center' })
         },

--- a/src/hooks/mutations/post/use-toggle-post-like.ts
+++ b/src/hooks/mutations/post/use-toggle-post-like.ts
@@ -3,26 +3,24 @@ import { queryKeys } from '@/hooks/queries/query-keys'
 import type { Post, UseMutationCallback } from '@/types'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
-export default function useTogglePostLike(callbacks?: UseMutationCallback) {
+export default function useTogglePostLike(postId: string, callbacks?: UseMutationCallback) {
     const queryClient = useQueryClient()
 
     return useMutation({
         mutationFn: togglePostLike,
         onMutate: async ({ postId, userId }) => {
-            // 진행 중인 쿼리 취소
             await queryClient.cancelQueries({ queryKey: queryKeys.posts })
+            await queryClient.cancelQueries({ queryKey: queryKeys.post(postId) })
 
-            // 현재 데이터 백업
             const previousPosts = queryClient.getQueryData<Post[]>(queryKeys.posts)
+            const previousPost = queryClient.getQueryData<Post>(queryKeys.post(postId))
 
-            // 낙관적 업데이트
+            // 목록 낙관적 업데이트
             queryClient.setQueryData<Post[]>(queryKeys.posts, (old) => {
                 if (!old) return old
                 return old.map((post) => {
                     if (post.id !== postId) return post
-
                     const isLiked = post.post_likes.some((like) => like.user_id === userId)
-
                     return {
                         ...post,
                         post_likes: isLiked
@@ -32,16 +30,32 @@ export default function useTogglePostLike(callbacks?: UseMutationCallback) {
                 })
             })
 
-            return { previousPosts }
+            // 상세 낙관적 업데이트
+            queryClient.setQueryData<Post>(queryKeys.post(postId), (old) => {
+                if (!old) return old
+                const isLiked = old.post_likes.some((like) => like.user_id === userId)
+                return {
+                    ...old,
+                    post_likes: isLiked
+                        ? old.post_likes.filter((like) => like.user_id !== userId)
+                        : [...old.post_likes, { id: crypto.randomUUID(), user_id: userId }],
+                }
+            })
+
+            return { previousPosts, previousPost }
         },
         onError: (error, _, context) => {
             if (context?.previousPosts) {
                 queryClient.setQueryData(queryKeys.posts, context.previousPosts)
             }
+            if (context?.previousPost) {
+                queryClient.setQueryData(queryKeys.post(postId), context.previousPost)
+            }
             if (callbacks?.onError) callbacks.onError(error)
         },
         onSettled: () => {
             queryClient.invalidateQueries({ queryKey: queryKeys.posts })
+            queryClient.invalidateQueries({ queryKey: queryKeys.post(postId) })
         },
     })
 }

--- a/src/hooks/queries/query-keys.ts
+++ b/src/hooks/queries/query-keys.ts
@@ -1,3 +1,5 @@
 export const queryKeys = {
     posts: ['posts'] as const,
+    post: (id: string) => ['post', id] as const,
+    comments: (postId: string) => ['comments', postId] as const,
 }

--- a/src/hooks/queries/use-post-data.ts
+++ b/src/hooks/queries/use-post-data.ts
@@ -1,9 +1,10 @@
 import { fetchPost } from '@/api/post'
 import { useQuery } from '@tanstack/react-query'
+import { queryKeys } from './query-keys'
 
 export function usePostData(id: string) {
     return useQuery({
-        queryKey: ['post', id],
+        queryKey: queryKeys.post(id),
         queryFn: () => fetchPost(id),
     })
 }


### PR DESCRIPTION
## 구현 내용

### 좋아요 자동 갱신
- 상세 페이지에서도 좋아요 낙관적 업데이트 적용
- queryKeys에 단건 포스트 키 추가
- useTogglePostLike에서 목록/상세 페이지 동시 갱신

## 논의 사항
- 대댓글 기능 (post_comments 테이블에 parent_id 컬럼 추가 필요)