### PR TITLE
feat: 마이페이지에서 내 게시글만 필터링 기능 추가

### DIFF
--- a/src/app/components/post/PostListPage.tsx
+++ b/src/app/components/post/PostListPage.tsx
@@ -1,11 +1,16 @@
+import { useSearchParams } from 'react-router'
 import CreatePostButton from './create-post-button'
 import PostFeed from './post-feed'
 
 export function PostListPage() {
+    // 마이페이지에서 ?userId=... 파라미터로 진입 시 해당 유저의 게시글만 표시
+    const [searchParams] = useSearchParams()
+    const userId = searchParams.get('userId') ?? undefined
+
     return (
         <div className="flex flex-col gap-10">
             <CreatePostButton />
-            <PostFeed />
+            <PostFeed userId={userId} />
         </div>
     )
 }

--- a/src/app/components/post/post-feed.tsx
+++ b/src/app/components/post/post-feed.tsx
@@ -1,10 +1,15 @@
+import { useUserPostsData } from '@/hooks/queries/use-user-posts-data'
 import { usePostsData } from '@/hooks/queries/use-posts-data'
 import Fallback from '../common/ErrorFallback'
 import Loader from '../common/LoadingSpinner'
 import PostItem from './post-item'
 
-export default function PostFeed() {
-    const { data, error, isPending } = usePostsData()
+export default function PostFeed({ userId }: { userId?: string }) {
+    const allPosts = usePostsData()
+    const userPosts = useUserPostsData(userId ?? '')
+
+    // userId가 있으면 내 게시글만, 없으면 전체 게시글 표시
+    const { data, error, isPending } = userId ? userPosts : allPosts
 
     if (error) return <Fallback />
     if (isPending) return <Loader />

--- a/src/hooks/queries/use-user-posts-data.ts
+++ b/src/hooks/queries/use-user-posts-data.ts
@@ -1,0 +1,11 @@
+import { fetchUserPosts } from '@/supabase/query/post/post'
+import { useQuery } from '@tanstack/react-query'
+
+// 특정 유저가 작성한 게시글 목록을 조회하는 훅
+// queryKey를 ['posts', 'user', userId]로 분리해 전체 게시글 캐시와 독립적으로 관리
+export function useUserPostsData(userId: string) {
+    return useQuery({
+        queryKey: ['posts', 'user', userId],
+        queryFn: () => fetchUserPosts(userId),
+    })
+}

--- a/src/supabase/query/post/post.ts
+++ b/src/supabase/query/post/post.ts
@@ -100,7 +100,14 @@ export async function fetchPostCountByUser(userId: string) {
 export async function fetchUserPosts(userId: string) {
     const { data, error } = await supabase
         .from('post')
-        .select('id, title, content, created_at')
+        .select(
+            `
+            *,
+            post_images (image_url),
+            post_likes (id, user_id),
+            post_comments (id)
+        `,
+        )
         .eq('user_id', userId)
         .order('created_at', { ascending: false })
 


### PR DESCRIPTION
## 📋 개요

마이페이지에서 "작성한 게시물" 클릭 시 전체 게시글이 아닌 내가 작성한 게시글만 표시되도록 기능 추가

---

## 🔧 변경 사항

### `src/supabase/query/post/post.ts`
- `fetchUserPosts` 쿼리에 `post_images`, `post_likes`, `post_comments` 포함하도록 수정
- 기존에는 `id, title, content, created_at` 만 조회해서 PostItem 렌더링 불가했던 문제 해결

### `src/hooks/queries/use-user-posts-data.ts` (신규)
- `fetchUserPosts`를 React Query로 감싸는 훅 생성
- `queryKey: ['posts', 'user', userId]` 로 전체 게시글 캐시와 독립적으로 관리

### `src/app/components/post/post-feed.tsx`
- `userId` prop 추가
- `userId` 있으면 `useUserPostsData` → 내 게시글만 표시
- `userId` 없으면 기존 `usePostsData` → 전체 게시글 표시

### `src/app/components/post/PostListPage.tsx`
- `useSearchParams`로 URL의 `?userId=` 파라미터를 읽어서 `PostFeed`에 전달

---

## ✅ 테스트 체크리스트

- [x] 마이페이지 "작성한 게시물" 클릭 시 내 게시글만 표시되는지 확인
- [x] 자유게시판 직접 진입 시 전체 게시글 정상 표시되는지 확인
- [x] 게시글 없을 경우 빈 화면 정상 표시되는지 확인
