### PR TITLE
fix: Vercel SPA 라우팅 설정 추가 (새로고침 404 해결)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## 📋 개요

페이지 새로고침 또는 URL 직접 입력 시 404가 뜨는 문제 해결

## 🔧 원인 및 해결

- **원인**: Vercel이 `/mypage` 등의 경로 요청 시 실제 파일을 찾으려 하지만 SPA는 `index.html` 하나만 존재
- **해결**: `vercel.json` 추가하여 모든 요청을 `index.html`로 리다이렉트, React Router가 라우팅 처리하도록 수정

## 📂 변경 파일

- `vercel.json` 신규 추가
